### PR TITLE
Fix vulnerable http dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,9 +106,9 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.11.3+17"
+    version: "0.13.3"
   http_multi_server:
     dependency: transitive
     description:
@@ -120,9 +120,9 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
@@ -169,9 +169,9 @@ packages:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
@@ -211,9 +211,9 @@ packages:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.2"
+    version: "1.8.0"
   plugin:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  http: ^0.11.0
+  http: ^0.13.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- bump `http` dependency to 0.13.3
- update lock file entries to match

## Testing
- `flutter test` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb77a780c832a986d2a6d80346315